### PR TITLE
Update GoToWebinar's Base URL

### DIFF
--- a/lib/omniauth/gotowebinar/version.rb
+++ b/lib/omniauth/gotowebinar/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module GoToWebinar
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/omniauth/strategies/gotowebinar.rb
+++ b/lib/omniauth/strategies/gotowebinar.rb
@@ -6,7 +6,7 @@ module OmniAuth
       option :name, 'gotowebinar'
 
       option :client_options, {
-        :site           => 'https://api.citrixonline.com',
+        :site           => 'https://api.getgo.com',
         :authorize_url  => '/oauth/authorize',
         :token_url      => '/oauth/access_token'
       }

--- a/spec/omniauth/strategies/gotowebinar_spec.rb
+++ b/spec/omniauth/strategies/gotowebinar_spec.rb
@@ -25,7 +25,7 @@ describe OmniAuth::Strategies::GoToWebinar do
 
     describe '#client' do
       it 'has correct GoToWebinar site' do
-        subject.client.site.should eq('https://api.citrixonline.com')
+        subject.client.site.should eq('https://api.getgo.com')
       end
 
       it 'has correct authorize url' do


### PR DESCRIPTION
https://redmine.wishpond.com/issues/104227025

Problem:
Effective Dec 4, 2017 GoToWebinar has changed it base url for all
API calls from https://api.citrixonline.com to
https://api.getgo.com

Solution:
Update the base URL, update specs
  

More info: https://goto-developer.logmeininc.com/content/important-changes-goto-developer-center-new-domains-apis